### PR TITLE
Patients now optimize for a particular bed if possible.

### DIFF
--- a/Source/Hospital/Patches/Patients_BedFinder_Patch.cs
+++ b/Source/Hospital/Patches/Patients_BedFinder_Patch.cs
@@ -21,23 +21,35 @@ public class Patients_BedFinder_Patch
         {
             if (sleeper.IsPatient(out _) && !sleeper.InBed())
             {
-                // try to find hospital bed
+                //Find any hospital bed
                 __result = sleeper.Map.listerBuildings.AllBuildingsColonistOfClass<Building_Bed>().Where(
                         bed => bed.Medical
-                               && bed.GetComp<CompHospitalBed>() != null
-                               && bed.GetComp<CompHospitalBed>().Hospital
-                               && RestUtility.IsValidBedFor(bed, sleeper, traveler, checkSocialProperness: false))
+                                && bed.GetComp<CompHospitalBed>() != null
+                                && bed.GetComp<CompHospitalBed>().Hospital
+                                && RestUtility.IsValidBedFor(bed, sleeper, traveler, checkSocialProperness: false))
                     .FirstOrFallback(__result);
-                //try to find even better hospital bed
-                if (sleeper.health.surgeryBills.Count > 0)
-                {
+                // Try to find hospital bed for a patient that does not require surgery
+                if (sleeper.health.surgeryBills.Count <= 0) {
+                    
                     __result = sleeper.Map.listerBuildings.AllBuildingsColonistOfClass<Building_Bed>().Where(
-                            bed => bed.Medical
-                                   && bed.GetComp<CompHospitalBed>() != null
-                                   && bed.GetComp<CompHospitalBed>().Surgery                                   
-                                   && RestUtility.IsValidBedFor(bed, sleeper, traveler, checkSocialProperness: false))
-                        .FirstOrFallback(__result);
-                }            
+                        bed => bed.Medical
+                                && bed.GetComp<CompHospitalBed>() != null
+                                && bed.GetComp<CompHospitalBed>().Hospital
+                                && !bed.GetComp<CompHospitalBed>().Surgery 
+                                && RestUtility.IsValidBedFor(bed, sleeper, traveler, checkSocialProperness: false))
+                    .FirstOrFallback(__result);
+                }
+                // Try to find hospital bed for a patient that does surgery
+                if (sleeper.health.surgeryBills.Count > 0) {
+
+                    __result = sleeper.Map.listerBuildings.AllBuildingsColonistOfClass<Building_Bed>().Where(
+                        bed => bed.Medical
+                                && bed.GetComp<CompHospitalBed>() != null
+                                && bed.GetComp<CompHospitalBed>().Hospital
+                                && bed.GetComp<CompHospitalBed>().Surgery 
+                                && RestUtility.IsValidBedFor(bed, sleeper, traveler, checkSocialProperness: false))
+                    .FirstOrFallback(__result);
+                }
             }
         }
     }


### PR DESCRIPTION
The logic should go as follows: 
Patient finds any bed that is tagged hospital regardless of surgery bill count.
If the patient has zero surgery bills then it will search for a bed that is tagged hospital, and NOT surgery. 
if the patient has any surgery bills then it will search for a bed that is tagged hospital and surgery. 

Please double check that this works, I found no issues on my system running this, but I also have never done any rim world modding.