### PR TITLE
Fix NREs, multi-map state desync, and Mass Casualty Event crash

### DIFF
--- a/Source/Hospital/AI/LordJob_VisitColonyAsPatient.cs
+++ b/Source/Hospital/AI/LordJob_VisitColonyAsPatient.cs
@@ -52,6 +52,6 @@ public class LordJob_VisitColonyAsPatient : LordJob
         public override void Notify_PawnLost(Pawn pawn, PawnLostCondition condition)
         {
             //Log.Message($"{pawn.NameFullColored} lost because of {condition}");
-            Find.CurrentMap.GetComponent<HospitalMapComponent>().DismissPatient(pawn);
+            (pawn.MapHeld ?? lord?.Map)?.GetComponent<HospitalMapComponent>()?.DismissPatient(pawn);
         }
 }

--- a/Source/Hospital/Hospital/HospitalMapComponent.cs
+++ b/Source/Hospital/Hospital/HospitalMapComponent.cs
@@ -119,9 +119,12 @@ namespace Hospital
         {
             if (Patients.TryGetValue(pawn, out var patientData))
             {
-                int penalty = HospitalMod.Settings.DeathGoodwillPenalty;
-                Messages.Message($"{pawn.NameFullColored} died: -{penalty} "+pawn.Faction.name, MessageTypeDefOf.PawnDeath);
-                pawn.Faction.TryAffectGoodwillWith(Faction.OfPlayer, -penalty, false);
+                if (pawn.Faction != null)
+                {
+                    int penalty = HospitalMod.Settings.DeathGoodwillPenalty;
+                    Messages.Message($"{pawn.NameFullColored} died: -{penalty} "+pawn.Faction.name, MessageTypeDefOf.PawnDeath);
+                    pawn.Faction.TryAffectGoodwillWith(Faction.OfPlayer, -penalty, false);
+                }
                 RemoveFromPatientList(pawn);
                 PatientLeftTheMap(pawn);
             }
@@ -132,9 +135,12 @@ namespace Hospital
         {
             if (Patients.TryGetValue(pawn, out var patientData))
             {
-                int penalty = HospitalMod.Settings.SurgeryFailGoodwillPenalty;
-                Messages.Message($"{pawn.NameFullColored} failed: -{penalty} "+pawn.Faction.name, MessageTypeDefOf.PawnDeath);
-                pawn.Faction.TryAffectGoodwillWith(Faction.OfPlayer, -penalty, false);
+                if (pawn.Faction != null)
+                {
+                    int penalty = HospitalMod.Settings.SurgeryFailGoodwillPenalty;
+                    Messages.Message($"{pawn.NameFullColored} failed: -{penalty} "+pawn.Faction.name, MessageTypeDefOf.PawnDeath);
+                    pawn.Faction.TryAffectGoodwillWith(Faction.OfPlayer, -penalty, false);
+                }
                 patientData.Bill = 0f;
                 RemoveFromPatientList(pawn);
                 PatientLeftTheMap(pawn);

--- a/Source/Hospital/IncidentSchedule/IncidentScheduler.cs
+++ b/Source/Hospital/IncidentSchedule/IncidentScheduler.cs
@@ -27,7 +27,7 @@ public class IncidentScheduler : MapComponent
         base.MapComponentTick();
         if (GenTicks.TicksGame % 42 == 0) // every ingame minute
         {
-            int freebeds = Find.CurrentMap.GetComponent<HospitalMapComponent>().FreeMedicalBeds();
+            int freebeds = map.GetComponent<HospitalMapComponent>().FreeMedicalBeds();
             // every ingame minute there is a chance of patients arriving minute
             float baseChance = 0.004f; // 1% every minute, gives about a patient per 100 minutes  
             if (GenDate.DaysPassed % 2 == 0)

--- a/Source/Hospital/IncidentWorker/IncidentWorker_MassCasualtyEvent.cs
+++ b/Source/Hospital/IncidentWorker/IncidentWorker_MassCasualtyEvent.cs
@@ -53,6 +53,7 @@ namespace Hospital
                 parms.pawnCount = hospital.BedCount() + Rand.Range(-hospital.BedCount() / 5, 1); // a bit more than the hospital can handle.
             }
             List<Faction> factions = Find.FactionManager.AllFactions.Where(f => !f.IsPlayer && !f.defeated && !f.def.hidden && !f.HostileTo(Faction.OfPlayer) && f.def.humanlikeFaction && !f.def.defName.ToUpper().Contains("VREA")).ToList();
+            if (factions.Count == 0) return false;
             parms.faction = factions.RandomElement();
             /*foreach (Faction def in factions)
             {


### PR DESCRIPTION
Resolves four critical runtime issues causing `NullReferenceException` log spam on world map view, patient state desynchronization on multi-map saves, unhandled exceptions with factionless patients, and a crash on Mass Casualty Events when no valid factions exist.

* **Fix NRE & Multi-Map Logic in `IncidentScheduler`**
  * Replaced `Find.CurrentMap` with the component's `map` reference in `MapComponentTick`.
  * Fixes `NullReferenceException` spam when viewing the World Map and prevents checking bed capacity on the wrong map during multi-colony playthroughs.

* **Fix NRE & Wrong-Map Dismissal in `LordJob_VisitColonyAsPatient`**
  * Updated `Notify_PawnLost` to resolve the map via `(pawn.MapHeld ?? lord?.Map)`.
  * Fixes NREs when a pawn is lost while the player is on the World Map and ensures patient data is removed from the correct map's component.

* **Add Null Safeguards for Factionless Patients in `HospitalMapComponent`**
  * Wrapped goodwill adjustments in `PatientDied` and `SurgeryFailed` in `if (pawn.Faction != null)` checks.
  * Prevents NREs when factionless patients (e.g., space refugees, wild men, ancients) die or fail surgery, allowing roster cleanup to proceed normally.

* **Prevent Empty List Crash in `IncidentWorker_MassCasualtyEvent`**
  * Added `if (factions.Count == 0) return false;` prior to calling `factions.RandomElement()`.
  * Fixes an unhandled `InvalidOperationException` crash when no non-hostile humanlike factions exist on the world map.